### PR TITLE
[BE] feat: 회원가입 시 이메일 검증 및 인증코드 검증

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/com/pill/member/config/EmailConfig.java
+++ b/backend/src/main/java/com/pill/member/config/EmailConfig.java
@@ -1,0 +1,68 @@
+package com.pill.member.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/backend/src/main/java/com/pill/member/controller/MemberController.java
+++ b/backend/src/main/java/com/pill/member/controller/MemberController.java
@@ -1,24 +1,65 @@
 package com.pill.member.controller;
 
 import com.pill.member.dto.CreateMemberDto;
+import com.pill.member.service.MailService;
 import com.pill.member.service.MemberService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.json.JSONParser;
+import org.springframework.boot.json.JsonParser;
+import org.springframework.boot.web.servlet.server.Session;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
+    private final MailService mailService;
 
-    @PostMapping
-    public ResponseEntity<Long> createMember(@RequestBody CreateMemberDto createMemberDto) {
-        Long memberId = memberService.createMember(createMemberDto);
-        return ResponseEntity.ok(memberId);
+    @PostMapping("/register/email")
+    public ResponseEntity<Map<String, String>> sendEmail(@RequestBody @Valid CreateMemberDto createMemberDto, BindingResult bindingResult, HttpSession seession) {
+        Map<String, String> result = new HashMap<>();
+
+        if (bindingResult.hasErrors()) {
+            result.put("error", bindingResult.getFieldError().getDefaultMessage());
+            return ResponseEntity.badRequest().body(result);
+        }
+
+        String authCode = generateCode();
+        seession.setAttribute("authCode", authCode);
+        mailService.sendEmail(createMemberDto.email(), "pill 이메일 인증", "인증코드: " + authCode);
+        result.put("message", "이메일 전송 성공");
+        result.put("email", createMemberDto.email());
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/register/email-auth")
+    public ResponseEntity<Map<String, String>> checkEmail(@RequestBody HashMap<String, String> authCode, HttpSession session) {
+        Map<String, String> result = new HashMap<>();
+        String code = (String)session.getAttribute("authCode");
+
+        if (authCode.get("authCode").isEmpty() || !authCode.get("authCode").equals(code)) {
+            result.put("error", "인증코드가 일치하지 않습니다.");
+            return ResponseEntity.badRequest().body(result);
+        }
+
+        result.put("message", "이메일 인증 성공");
+        return ResponseEntity.ok(result);
+    }
+
+    public String generateCode() {
+        return String.valueOf(ThreadLocalRandom.current().nextInt(100000, 1000000));
     }
 }

--- a/backend/src/main/java/com/pill/member/domain/Member.java
+++ b/backend/src/main/java/com/pill/member/domain/Member.java
@@ -24,11 +24,21 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer age;
+
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
     public Member(String email, String password) {
         this.email = email;
         this.password = password;
+    }
+
+    public Member(String email) {
+        this.email = email;
     }
 }

--- a/backend/src/main/java/com/pill/member/dto/CreateMemberDto.java
+++ b/backend/src/main/java/com/pill/member/dto/CreateMemberDto.java
@@ -2,12 +2,14 @@ package com.pill.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record CreateMemberDto(
-        @Email @NotBlank
-        String email,
-        @NotBlank
-        String password
+        @Email(message = "유효하지 않은 이메일 주소입니다.")
+        @NotBlank(message = "이메일은 공백일 수 없습니다.")
+        String email
+        //@NotBlank
+        //String password
 ) {
 
 }

--- a/backend/src/main/java/com/pill/member/service/MailService.java
+++ b/backend/src/main/java/com/pill/member/service/MailService.java
@@ -1,0 +1,39 @@
+package com.pill.member.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender emailSender;
+
+    public void sendEmail(String toEmail, String title, String text) {
+        SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+
+        try {
+            emailSender.send(emailForm);
+        } catch (RuntimeException e) {
+            log.debug("MailService.sendEmail exception occur toEmail: {}, " +
+                    "title: {}, text: {}", toEmail, title, text);
+        }
+    }
+
+    private SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+}

--- a/backend/src/main/java/com/pill/member/service/MemberService.java
+++ b/backend/src/main/java/com/pill/member/service/MemberService.java
@@ -16,7 +16,7 @@ public class MemberService {
 
     @Transactional
     public Long createMember(CreateMemberDto createMemberDto) {
-        Member member = new Member(createMemberDto.email(), createMemberDto.password());
+        Member member = new Member(createMemberDto.email());
         memberRepository.save(member);
 
         return member.getId();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
       on-profile: local
   datasource:
     hikari:
-      jdbc-url: jdbc:mysql://localhost:3306/pill?useUnicode=true&characterEncoding=utf8
+      jdbc-url: jdbc:mysql://localhost:3307/pill?useUnicode=true&characterEncoding=utf8
       username: root
       password: 1111
       driver-class-name: com.mysql.cj.jdbc.Driver
@@ -20,3 +20,19 @@ spring:
         show_sql: true
     hibernate:
       ddl-auto: create
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_KEY}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30분


### PR DESCRIPTION
[/register/email] 최초 이메일 입력 화면
요청 (JSON)
{
    "email": "~"
}

응답 (JSON)
성공 시 --> 이메일 인증코드 전송
{
    "message": "이메일 전송 성공",
    "email": "~"
    # 입력한 이메일 반환
}

실패 시 (이메일 잘못 입력)
{
    "error":  "인증코드가 일치하지 않습니다."
}

[/register/email-auth] 이메일 인증 코드 검증
세션에 저장된 인증코드와 비교
요청 (JSON) --> 이메일로 받은 인증코드 입력
{
    "authCode": "~"
}

성공 시 (JSON)
{
    "message": "이메일 인증 성공"
}

실패 시
{
    "error": "인증코드가 일치하지 않습니다."
}